### PR TITLE
Response code 302 is valid reply for /resolve.

### DIFF
--- a/Services/Soundcloud.php
+++ b/Services/Soundcloud.php
@@ -878,7 +878,7 @@ class Services_Soundcloud
      */
     protected function _validResponseCode($code)
     {
-        return (bool)preg_match('/^20[0-9]{1}$/', $code);
+        return (bool)preg_match('/^20[0-9]{1}$|^302$/', $code);
     }
 
     /**

--- a/tests/Soundcloud_Test.php
+++ b/tests/Soundcloud_Test.php
@@ -178,6 +178,10 @@ class Soundcloud_Test extends PHPUnit_Framework_TestCase {
         self::assertTrue($this->soundcloud->validResponseCode(200));
     }
 
+    function testResponseCodeResolve() {
+        self::assertTrue($this->soundcloud->validResponseCode(302));
+    }
+
     function testResponseCodeRedirect() {
         self::assertFalse($this->soundcloud->validResponseCode(301));
     }


### PR DESCRIPTION
Presently you can't get the actual response from /resolve which is as documented supposed to be a 302
https://developers.soundcloud.com/docs/api/reference#apps

It shouldn't be required that the user of the wrapper add the curlopt (CURLOPT_FOLLOWLOCATION => true) and then follow and get the resource returned if they only want to resolve the URL.

Other 30x remain invalid replies.